### PR TITLE
Color Refinement List: put hex code after the color name

### DIFF
--- a/color-refinement-list/react-instantsearch/README.md
+++ b/color-refinement-list/react-instantsearch/README.md
@@ -10,7 +10,7 @@
 
 This is the `ColorRefinementList` Labs widget for [React InstantSearch](https://community.algolia.com/react-instantsearch/). You can use this widget to refine results by color tags with Algolia.
 
-This widget displays the colors of the formated facet. The facet value should have a hex code and a title separated by a ';' (Eg. `#000;black`)
+This widget displays the colors of the formated facet. The facet value should have a title and hex code separated by a ';' (Eg. `black;#000`)
 
 This helps the user quickly visualise the kind of color that you have in your index.
 This is a great widget to refine records within multiple shades of a single color (like choosing the color of a jean).
@@ -73,7 +73,7 @@ To work properly, **you'll need to specify the record attribute corresponding to
 | --------------------------------- | --------- | --------------------------------------------------- |
 | attribute (required)              | string    | Name of the attribute that contains the color       |
 
-Please note that the records' color attributes need to be formatted like `#eaeaea;grey` (hexadecimal color and color name separated by a semicolon) for the widget to work.
+Please note that the records' color attributes need to be formatted like `grey;#eaeaea` (color name and hexadecimal color separated by a semicolon) for the widget to work.
 
 ## Implementation details
 

--- a/color-refinement-list/react-instantsearch/package.json
+++ b/color-refinement-list/react-instantsearch/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/algolia/instantsearch-labs/tree/master/color-refinement-list/react-instantsearch"
   },
-  "version": "0.1.6-a",
+  "version": "0.1.7",
   "private": false,
   "dependencies": {
     "react-instantsearch": "^5.3.1",

--- a/color-refinement-list/react-instantsearch/package.json
+++ b/color-refinement-list/react-instantsearch/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/algolia/instantsearch-labs/tree/master/color-refinement-list/react-instantsearch"
   },
-  "version": "0.1.5",
+  "version": "0.1.6-a",
   "private": false,
   "dependencies": {
     "react-instantsearch": "^5.3.1",

--- a/color-refinement-list/react-instantsearch/src/lib/ColorRefinementList.css
+++ b/color-refinement-list/react-instantsearch/src/lib/ColorRefinementList.css
@@ -6,27 +6,27 @@ li[status="checked"].ais-ColorRefinementElement:before {
 
 li.ais-ColorRefinementElement:before {
   content: "\2714";
-  visibility: hidden;
   color: #fff;
-  display: inline-block;
+  visibility: hidden;  
   position: relative;
-  top: -1px;
   font-size: 10px;
 }
 
 .ais-ColorRefinementElement {
   float: left;
-  width: 24px;
-  height: 19px;
+  width: 30px;
   text-align: center;
   cursor: pointer;
   margin: 0px 2px 3px 0px;
   padding-bottom: 0px;
   box-shadow: inset 0px 0px 0px 1px #d9d9d9;
+  align-items: center;
+  line-height: 20px;
 }
 
 ul.ais-ColorRefinementList-container {
   margin: 0;
+  display: inline-block;
 }
 
 .ais-ColorRefinementList-container {

--- a/color-refinement-list/react-instantsearch/src/lib/ColorRefinementList.js
+++ b/color-refinement-list/react-instantsearch/src/lib/ColorRefinementList.js
@@ -20,10 +20,10 @@ class ColorRefinementList extends Component {
                     ) : null}
                     {this.props.items.map(item => {
                         const color =
-                            item.label.split(";")[0].length === 4
-                                ? item.label.split(";")[0] +
-                                item.label.split(";")[0].slice(1, 4)
-                                : item.label.split(";")[0];
+                            item.label.split(";")[1].length === 4
+                                ? item.label.split(";")[1] +
+                                item.label.split(";")[1].slice(1, 4)
+                                : item.label.split(";")[1];
 
                         return (
                             <a


### PR DESCRIPTION
I tried to import it straight away and realized that the tick icon wasn't center (other css was affecting the display) Here is a fix !